### PR TITLE
Fix CUDA tensor to numpy conversion error in apply_grappa_kernel

### DIFF
--- a/src/ggrappa/application.py
+++ b/src/ggrappa/application.py
@@ -62,7 +62,7 @@ def apply_grappa_kernel(sig,
         if not torch.all(sig_sampled_pat[y_multi*tbly+shift_y:y_multi*tbly+shift_y+sbly, z_multi*tblz+shift_z+cnt:z_multi*tblz+shift_z+sblz+cnt] == kernel_pat):
             warnings.warn("Could not find the kernel pattern in the sampled region. Using the center of the sampled region as the kernel pattern.")
     else:
-        shift_y, shift_z = abs(sig).sum(0).sum(-1).nonzero()[0]
+        shift_y, shift_z = abs(sig).sum(0).sum(-1).nonzero()[0].cpu()
         #sig = torch.nn.functional.pad(sig,  (xpos, (sblx-xpos-tblx),
         #                                    (af[1] - zpos)%tblz + zpos, (sblz-zpos-tblz),
         #                                    (af[0] - ypos)%tbly + ypos, (sbly-ypos-tbly)))


### PR DESCRIPTION
When `sig` is on CUDA, `nonzero()[0]` returns a CUDA tensor. 
Unpacking it into `shift_y, shift_z` gives CUDA scalars, which 
then fail when added to a numpy array on line 84 (`zival = cnt + z_ival`).

Fix: add `.cpu()` to move the tensor to CPU before unpacking.

Reproduces with any CUDA input when `cuda=True` or `cuda_mode="all"`.
